### PR TITLE
Add new feature to group received EnOcean messages

### DIFF
--- a/enoceanmqtt/communicator.py
+++ b/enoceanmqtt/communicator.py
@@ -240,9 +240,9 @@ class Communicator:
 
             # loop through all EEP properties
             for prop_name in properties:
+                found_property = True
                 if prop_name == channel_id:
                     continue
-                found_property = True
                 cur_prop = packet.parsed[prop_name]
                 # we only extract numeric values, either the scaled ones
                 # or the raw values for enums

--- a/enoceanmqtt/enoceanmqtt.py
+++ b/enoceanmqtt/enoceanmqtt.py
@@ -59,7 +59,7 @@ def load_config_file(config_files):
                 new_sens = {'name': mqtt_prefix + section}
                 for key in config_parser[section]:
                     try:
-                        if key == 'command':
+                        if key in ('command', 'channel'):
                             new_sens[key] = config_parser[section][key]
                         else:
                             new_sens[key] = int(config_parser[section][key], 0)


### PR DESCRIPTION
Add new feature allowing to group received EnOcean messages depending on the value of a field of that message.
This is useful for EnOcean devices with two or more channels (i.e. D2-01-12)
Considering D2-01-12 as an example, by adding 'channel = IO' under such a device's configuration in enoceanmqtt.conf, all received messages featuring the IO field will be grouped such as:
`<sensor_name>/IOx/<prop_name>` where x is the channel ID (0, 1, 2, ...).
Hence, to receive channel 0 output state, one should subscribe to `<sensor_name>/IO0/OV`.
Without that feature, the output state and the corresponding channel would be received under different topics, requiring additional work to map state to channel.
    
This feature is only valid for received messages !