### PR TITLE
Multi-level grouping & handling of packet.learn

### DIFF
--- a/enoceanmqtt/communicator.py
+++ b/enoceanmqtt/communicator.py
@@ -294,10 +294,10 @@ class Communicator:
 
         # Determine MQTT topic
         topic = sensor['name']
-        for _id in channel_id:
-            if mqtt_json.get(_id) not in (None, ''):
-                topic += f"/{_id}{mqtt_json[_id]}"
-                del mqtt_json[_id]
+        for cur_id in channel_id:
+            if mqtt_json.get(cur_id) not in (None, ''):
+                topic += f"/{cur_id}{mqtt_json[cur_id]}"
+                del mqtt_json[cur_id]
 
         # Publish packet data to MQTT
         value = json.dumps(mqtt_json)


### PR DESCRIPTION
- Improve grouping mechanism previously added by allowing multilevel grouping:
  For example, for D2-01-12, defining `channel = IO/CMD` in the device configuration will group received data under IOx/CMDy where x and y are the values of IO and CMD fields in the received packet.
This improves message classification from multi-channel, multi-message EnOcean devices.

- Handling of packet.learn for VLD and RPS EnOcean devices:
Python EnOcean library always sets packet.learn to True for VLD and RPS EnOcean devices even if the received packet is not a learn packet. It is the responsibility of the library users to handle those cases.
RPS devices always send normal data telegrams so learn can always be considered false.
VLD ones use UTE telegrams as learn mechanism.
Hence, a packet once received is tested against aforementioned conditions to determine the correct value of packet.learn