### PR TITLE
Fix some exceptions

### DIFF
--- a/enoceanmqtt/communicator.py
+++ b/enoceanmqtt/communicator.py
@@ -266,9 +266,10 @@ class Communicator:
                # Check the current shortcut matches the command shortcut
                if source['shortcut'] == sensor.get('command'):
                    return packet.eep._get_raw(source, packet._bit_data)
-        else:
-            # If not found, return None for default handling of the packet
-            return None
+        
+        # If profile or command shortcut not found,
+        # return None for default handling of the packet
+        return None
 
     def _publish_mqtt(self, sensor, mqtt_json):
         '''Publish decoded packet content to MQTT'''

--- a/enoceanmqtt/communicator.py
+++ b/enoceanmqtt/communicator.py
@@ -258,16 +258,17 @@ class Communicator:
         profile = packet.eep.find_profile(
             packet._bit_data, sensor['rorg'], sensor['func'], sensor['type'])
 
-        # Loop over profile contents
-        for source in profile.contents:
-            if not source.name:
-                continue
-            # Check the current shortcut matches the command shortcut
-            if source['shortcut'] == sensor.get('command'):
-                return packet.eep._get_raw(source, packet._bit_data)
-
-        # If not found, return None for default handling of the packet
-        return None
+        if profile:
+            # Loop over profile contents
+            for source in profile.contents:
+               if not source.name:
+                   continue
+               # Check the current shortcut matches the command shortcut
+               if source['shortcut'] == sensor.get('command'):
+                   return packet.eep._get_raw(source, packet._bit_data)
+        else:
+            # If not found, return None for default handling of the packet
+            return None
 
     def _publish_mqtt(self, sensor, mqtt_json):
         '''Publish decoded packet content to MQTT'''
@@ -347,7 +348,8 @@ class Communicator:
             command = None
             if sensor.get('command'):
                 command = self._get_command_id(packet, sensor)
-                logging.debug('Retrieved command id from packet: %s', hex(command))
+                if command:
+                    logging.debug('Retrieved command id from packet: %s', hex(command))
 
             # Retrieve properties from EEP
             properties = packet.parse_eep(sensor['func'], sensor['type'], direction, command)


### PR DESCRIPTION
Fix some exceptions related to command id in VLD packets support.

1- In `get_command_id()`, when `profile` is not found, `profile.contents` triggered an exception. This is now detected and `None` is returned.
2- In `_handle_data_packet()`, when `command` is `None`, `hex(command)` triggered an exception. The debug message is now not printed in that case.

Sorry for missing these exceptions :disappointed: 

<br/>
By the way, one question not related to this PR.
In `run()`, should the transmitter ID request not be made outside the while loop ?