### PR TITLE
Support % character in MQTT password

### DIFF
--- a/enoceanmqtt/enoceanmqtt.py
+++ b/enoceanmqtt/enoceanmqtt.py
@@ -39,7 +39,7 @@ def load_config_file(config_files):
     global_config = {}
 
     for conf_file in config_files:
-        config_parser = ConfigParser(inline_comment_prefixes=('#', ';'))
+        config_parser = ConfigParser(inline_comment_prefixes=('#', ';'), interpolation=None)
         if not os.path.isfile(conf_file):
             logging.warning("Config file %s does not exist, skipping", conf_file)
             continue


### PR DESCRIPTION
At the moment, as configparser interpolation is enabled, MQTT passwords containing `%` character raise an exception. As interpolation seems to be not needed, the proposal is to set it to None so that MQTT passwords can now contain `%` character.

See mak-gitdev/HA_enoceanmqtt#37 for more details.