### PR TITLE
Publish packet receipt date

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,8 @@ Set the direction of the received packet for device needing an answer.
 #### default_data
 Default data to be sent to the device.
 > default_data = 0x80810408
+#### sender
+Use another sender ID to send command to the device.  
+This ID should be in the range \[Base_ID...Base_ID+127\].  
+For example, if your Base_ID is 0xFFDA5580, then you can set sender to any ID between 0xFFDA5580 and 0xFFDA55FF.
+> sender = 0xFFDA5581

--- a/README.md
+++ b/README.md
@@ -90,10 +90,45 @@ To send EnOcean messages you prepare the packet data by sending MQTT request to 
 
 An example: If you want to set the valve position (set point) of a heating actuator named `heating` (e.g. with `rorg = 0xA5`, `func = 0x20`, `type = 0x01`) to 80 % you publish the integer value 80 to the topic `enocean/heating/req/SP`. This replaces the corresponding part of `default_data`.
 
+<!--
 For VLD packets, you need to set the VLD type. For this, configure a `command` topic in the configuration file. Sending and MQTT request to this topic sets the command ID of the used EEP profile.
+-->
 
 To finally trigger the sending of the packet, place an MQTT message to the device's `req/send` topic. If you want to clear the customized data buffer back to default, set the MQTT payload to `clear`. Any other payload will keep the data buffer for further send requests.
 
 ### Answering EnOcean Messages ###
 
 Similar to sending EnOceam Messages you can configure it to send a packet as an answer to in incoming EnOcean packet. For this, you configure the `answer` switch in the device's configuration section. As above, you set the `default_data` in the config file and customize the response data by publishing MQTT messages to the device topic where you prefix the topic with `/req`.
+
+### List of device options
+
+#### persistent
+Publish the received EnOcean packet with the retain flag.
+> persistent = 1
+#### publish_json
+Publish the received EnOcean packet as a JSON-formatted message.
+> publish_json = True # or true or 1
+#### publish_rssi
+Publish the received RSSI.
+> publish_rssi = 1
+#### publish_date
+Publish the EnOcean packet received date.
+> publish_date = 1
+#### command
+For EEP supporting multiple commands, define the shortcut of the packet field used as command identifier.
+> command = CMD
+#### channel
+Group received EnOcean packet fields depending on the value of one of the fields.
+> channel = IO/CMD # Received data will be published to <device_root>/IOx/CMDy
+#### log_learn
+Forward learn messages to MQTT.
+> log_learn = 1
+#### answer
+Send data as an answer to an incoming packet.
+> answer = 1
+#### direction
+Set the direction of the received packet for device needing an answer.
+> direction = 1
+#### default_data
+Default data to be sent to the device.
+> default_data = 0x80810408

--- a/enoceanmqtt/communicator.py
+++ b/enoceanmqtt/communicator.py
@@ -276,6 +276,9 @@ class Communicator:
         # Publish using JSON format ?
         mqtt_publish_json = str(sensor.get('publish_json')) in ("True", "true", "1")
 
+        # Publish RSSI ?
+        mqtt_publish_rssi = str(sensor.get('publish_rssi')) in ("True", "true", "1")
+
         # Retain the to-be-published message ?
         retain = str(sensor.get('persistent')) in ("True", "true", "1")
 
@@ -285,26 +288,25 @@ class Communicator:
 
         # Handling Auxiliary data RSSI
         aux_data = {}
-        if str(sensor.get('publish_rssi')) in ("True", "true", "1"):
+        if mqtt_publish_rssi:
             if mqtt_publish_json:
-                # Keep RSSI out of groups
+                # Keep _RSSI_ out of groups
                 if channel_id:
-                    aux_data.update({"RSSI": mqtt_json['RSSI']})
-                    del mqtt_json['RSSI']
+                    aux_data.update({"_RSSI_": mqtt_json['_RSSI_']})
             else:
-                self.mqtt.publish(sensor['name']+"/RSSI", mqtt_json['RSSI'], retain=retain)
-                del mqtt_json['RSSI']
-        else:
-            del mqtt_json['RSSI']
+                self.mqtt.publish(sensor['name']+"/_RSSI_", mqtt_json['_RSSI_'], retain=retain)
+        # Delete RSSI if already handled
+        if channel_id or not mqtt_publish_json or not mqtt_publish_rssi:
+            del mqtt_json['_RSSI_']
 
         # Handling Auxiliary data _DATE_
         if str(sensor.get('publish_date')) in ("True", "true", "1"):
-            if mqtt_publish_json:
-                # Keep _DATE_ out of groups
-                if channel_id:
+            # Publish _DATE_ both at device and group levels
+            if channel_id:
+                if mqtt_publish_json:
                     aux_data.update({"_DATE_": mqtt_json['_DATE_']})
-            else:
-                self.mqtt.publish(sensor['name']+"/_DATE_", mqtt_json['_DATE_'], retain=retain)
+                else:
+                    self.mqtt.publish(sensor['name']+"/_DATE_", mqtt_json['_DATE_'], retain=retain)
         else:
             del mqtt_json['_DATE_']
 
@@ -341,12 +343,13 @@ class Communicator:
                 # Shall the packet be published to MQTT ?
                 if not packet.learn or str(cur_sensor.get('log_learn')) in ("True", "true", "1"):
                     # Store RSSI
-                    mqtt_json['RSSI'] = packet.dBm
+                    # Use underscore so that it is unique and doesn't
+                    # match a potential future EnOcean EEP field.
+                    mqtt_json['_RSSI_'] = packet.dBm
 
-                    # Store receive date _DATE_
-                    # Add underscore so that it is unique and
-                    # doesn't match a potential EnOcean EEP field.
-                    # If OK, may be the same could be done for RSSI ?
+                    # Store receive date
+                    # Use underscore so that it is unique and doesn't
+                    # match a potential future EnOcean EEP field.
                     mqtt_json['_DATE_'] = packet.received.isoformat()
 
                     # Handling received data packet


### PR DESCRIPTION
The EnOcean packet receipt date can be published to MQTT using device option `publish_date`. The date is published both on a device basis and on a command basis for devices supporting multiple commands.

Also added list of device options in readme